### PR TITLE
Some improvements to the repository interface and explanations.

### DIFF
--- a/README.ftl.md
+++ b/README.ftl.md
@@ -35,7 +35,7 @@ In this example, you store Customer objects, annotated as a JPA entity.
 
     <@snippet path="src/main/java/hello/Customer.java" prefix="complete"/>
 
-Here you have a `Customer` class with three attributes, the `id`, the `firstName`, and the `lastName`. You also have two constructors. The default constructor only exists for the sake of JPA. You won't use it directly, so it is designated as `private`. The other constructor is the one you'll use to create instances of `Customer` to be saved to the database.
+Here you have a `Customer` class with three attributes, the `id`, the `firstName`, and the `lastName`. You also have two constructors. The default constructor only exists for the sake of JPA. You won't use it directly, so it is designated as `protected`. The other constructor is the one you'll use to create instances of `Customer` to be saved to the database.
 
 > Note: In this guide, the typical getters and setters have been left out for brevity.
 
@@ -55,7 +55,7 @@ To see how this works, create a repository interface that works with `Customer` 
 
     <@snippet path="src/main/java/hello/CustomerRepository.java" prefix="complete"/>
     
-`CustomerRepository` extends the `JpaRepository` interface. The type of entity and ID that it works with,`Customer` and `Long`, are specified in the generic parameters on `JpaRepository`. By extending `JpaRepository`, `CustomerRepository` inherits several methods for working with `Customer` persistence, including methods for saving, deleting, and finding `Customer` entities.
+`CustomerRepository` extends the `CrudRepository` interface. The type of entity and ID that it works with,`Customer` and `Long`, are specified in the generic parameters on `CrudRepository`. By extending `CrudRepository`, `CustomerRepository` inherits several methods for working with `Customer` persistence, including methods for saving, deleting, and finding `Customer` entities.
 
 Spring Data JPA also allows you to define other query methods by simply declaring their method signature. In the case of `CustomerRepository`, this is shown with a `findByLastName()` method.
 
@@ -74,7 +74,7 @@ In the configuration, you need to add the `@EnableJpaRepositories` annotation. T
 Most of the content in `Application` sets up several beans to support Spring Data JPA and the sample: 
 
  * The `dataSource()` method defines a `DataSource` bean, as an embedded database to which the objects are persisted. 
- * The `entityManagerFactory()` method defines a `LocalContainerEntityManagerFactoryBean` that is ultimately used to create `LocalContainerEntityManagerFactory` a bean that implements the `EntityManagerFactory` interface. It is the bean through which JPA operations will be performed. Note that this factory bean's `packagesToScan` property is set to look for entities in the package named "hello". This makes it possible to work with JPA without defining a "persistence.xml" file.
+ * The `entityManagerFactory()` method defines a `LocalContainerEntityManagerFactoryBean` that is ultimately used to create a proxy bean that implements the `EntityManagerFactory` interface. It is the bean through which JPA operations will be performed. Note that this factory bean's `packagesToScan` property is set to look for entities in the package named "hello". This makes it possible to work with JPA without defining a "persistence.xml" file.
  * The `jpaVendorAdapter()` method defines a Hibernate-based JPA vendor adapter bean for use by the `EntityManagerFactory` bean.
  * The `transactionManager()` method defines a `JpaTransactionManager` bean for transactional persistence.
 

--- a/complete/pom.xml
+++ b/complete/pom.xml
@@ -4,7 +4,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.springframework</groupId>
-    <artifactId>gs-accessing-data-jpa</artifactId>
+    <artifactId>gs-accessing-data-jpa-complete</artifactId>
     <version>0.1.0</version>
 
     <parent>
@@ -46,8 +46,7 @@
     <build>
         <plugins>
             <plugin> 
-                <artifactId>maven-compiler-plugin</artifactId> 
-                <version>2.3.2</version> 
+                <artifactId>maven-compiler-plugin</artifactId>
             </plugin>
             <plugin>
                 <groupId>org.springframework.boot</groupId>

--- a/complete/src/main/java/hello/Application.java
+++ b/complete/src/main/java/hello/Application.java
@@ -4,7 +4,6 @@ import static org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType.
 
 import java.util.List;
 
-import javax.persistence.EntityManagerFactory;
 import javax.sql.DataSource;
 
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
@@ -48,8 +47,8 @@ public class Application {
     }
 
     @Bean
-    public PlatformTransactionManager transactionManager(EntityManagerFactory entityManagerFactory) {
-        return new JpaTransactionManager(entityManagerFactory);
+    public PlatformTransactionManager transactionManager() {
+        return new JpaTransactionManager();
     }
 
 
@@ -65,7 +64,7 @@ public class Application {
         repository.save(new Customer("Michelle", "Dessler"));
 
         // fetch all customers
-        List<Customer> customers = repository.findAll();
+        Iterable<Customer> customers = repository.findAll();
         System.out.println("Customers found with findAll():");
         System.out.println("-------------------------------");
         for (Customer customer : customers) {

--- a/complete/src/main/java/hello/Customer.java
+++ b/complete/src/main/java/hello/Customer.java
@@ -14,7 +14,7 @@ public class Customer {
     private String firstName;
     private String lastName;
 
-    private Customer() {}
+    protected Customer() {}
 
     public Customer(String firstName, String lastName) {
         this.firstName = firstName;

--- a/complete/src/main/java/hello/CustomerRepository.java
+++ b/complete/src/main/java/hello/CustomerRepository.java
@@ -2,10 +2,9 @@ package hello;
 
 import java.util.List;
 
-import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.CrudRepository;
 
-public interface CustomerRepository extends JpaRepository<Customer, Long> {
+public interface CustomerRepository extends CrudRepository<Customer, Long> {
 
     List<Customer> findByLastName(String lastName);
-
 }

--- a/initial/pom.xml
+++ b/initial/pom.xml
@@ -40,7 +40,6 @@
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Instead of extending JpaRepository we now extend CrudRepository as
using technology specific interfaces is not recommended in general. E.g.
JpaRepository exposes methods specific to JPA (as the name suggests) and
the purpose of the repository layer is to abstract the persistence
technology of choice.

In the configuration, the JpaTransactionManager doesn't need the
EntityManagerFactory as it will look it up by type anyway. So one less
thing to confuse the users with.

Fixed the description of the configuration class. There's no such thing
as an LocalContainerEntityManagerFactory actually.

Made default constructor in Customer protected to avoid compiler warnings.

Fixed the artifact identifier of the completion project as otherwise you
cannot import both projects into Eclipse as they will end up with the
same project name. Removed obsolete plugin versions for compiler plugin
to prevent Eclipse warnings show up.
