### PR TITLE
Fix `Customer`’s syntax

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -44,7 +44,7 @@ NOTE: In this guide, the typical getters and setters have been left out for brev
 
 The `Customer` class is annotated with `@Entity`, indicating that it is a JPA entity. For lack of a `@Table` annotation, it is assumed that this entity will be mapped to a table named `Customer`.
 
-The `Customer`'s `id` property is annotated with `@Id` so that JPA will recognize it as the object's ID. The `id` property is also annotated with `@GeneratedValue` to indicate that the ID should be generated automatically.
+The `Customer`’s `id` property is annotated with `@Id` so that JPA will recognize it as the object's ID. The `id` property is also annotated with `@GeneratedValue` to indicate that the ID should be generated automatically.
 
 The other two properties, `firstName` and `lastName` are left unannotated. It is assumed that they'll be mapped to columns that share the same name as the properties themselves.
 


### PR DESCRIPTION
    `Customer`'s `id`

displays incorrectly, but

    `Customer`’s `id`

works, at least in GitHub's renderer.

The Spring website displays the first version incorrectly, but I can't confirm whether the second will be any better.