### PR TITLE
Remove redundant configuration of JBoss's Maven repo

### DIFF
--- a/complete/build.gradle
+++ b/complete/build.gradle
@@ -20,7 +20,6 @@ bootJar {
 
 repositories {
     mavenCentral()
-    maven { url "https://repository.jboss.org/nexus/content/repositories/releases" }
 }
 
 sourceCompatibility = 1.8

--- a/complete/pom.xml
+++ b/complete/pom.xml
@@ -49,11 +49,6 @@
             <name>Spring Releases</name>
             <url>https://repo.spring.io/libs-release</url>
         </repository>
-        <repository>
-            <id>org.jboss.repository.releases</id>
-            <name>JBoss Maven Release Repository</name>
-            <url>https://repository.jboss.org/nexus/content/repositories/releases</url>
-        </repository>
     </repositories>
 
     <pluginRepositories>

--- a/initial/build.gradle
+++ b/initial/build.gradle
@@ -20,7 +20,6 @@ bootJar {
 
 repositories {
     mavenCentral()
-    maven { url "https://repository.jboss.org/nexus/content/repositories/releases" }
 }
 
 sourceCompatibility = 1.8

--- a/initial/pom.xml
+++ b/initial/pom.xml
@@ -49,11 +49,6 @@
             <name>Spring Releases</name>
             <url>https://repo.spring.io/libs-release</url>
         </repository>
-        <repository>
-            <id>org.jboss.repository.releases</id>
-            <name>JBoss Maven Release Repository</name>
-            <url>https://repository.jboss.org/nexus/content/repositories/releases</url>
-        </repository>
     </repositories>
 
     <pluginRepositories>


### PR DESCRIPTION
It isn't needed as everything's available from Central.